### PR TITLE
docs: add MCP setup and exercise checklist

### DIFF
--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,0 +1,22 @@
+# MCP setup and exercise checklist
+
+This repo already includes a working example for connecting an MCP server for GitHub Copilot.
+
+## What I added in this branch
+
+- `docs/mcp-setup.md` — this file (you are reading it).
+
+## Current repo status
+
+- `.vscode/mcp.json` — present and contains the example GitHub Copilot MCP server configuration.
+
+## Checklist (exercise steps)
+
+- [x] Verify `.vscode/mcp.json` exists in the repository
+- [ ] Confirm Agent mode and authenticate the MCP server in a Codespace (manual)
+- [ ] Verify Copilot shows the MCP tools (manual)
+- [ ] Mark the exercise as complete in Issue #1 (once the above are done)
+
+## Notes
+
+If you want me to push the exact `mcp.json` to `main` directly instead of a PR, tell me and I can open a small PR that targets `main` instead.


### PR DESCRIPTION
This PR adds a short `docs/mcp-setup.md` with a checklist and notes for the MCP exercise (Issue #1).

It documents that `.vscode/mcp.json` is present and lists manual verification steps remaining for the learner.

Related: closes or advances Issue #1 by making the repo status explicit.