### PR TITLE
feat: add minimal Admin Mode (teacher login + auth)

### DIFF
--- a/data/teachers.json
+++ b/data/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password": "changeme"
+    }
+  ]
+}

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,14 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-controls" class="auth-controls">
+        <form id="login-form">
+          <input type="text" id="login-username" placeholder="teacher username" />
+          <input type="password" id="login-password" placeholder="password" />
+          <button id="login-btn" type="submit">Login</button>
+          <button id="logout-btn" type="button" class="hidden">Logout</button>
+        </form>
+      </div>
     </header>
 
     <main>


### PR DESCRIPTION
This PR implements a minimal Admin Mode so only logged-in teachers can register/unregister students.

Changes:
- `src/app.py`: login/logout endpoints, `/auth/status`, and checks that restrict signup/unregister to teachers
- `data/teachers.json`: sample teacher credentials (username: `teacher`, password: `changeme`)
- `src/static/index.html` and `src/static/app.js`: small login UI and client-side wiring to show/hide signup controls

Notes:
- This is intentionally simple (cookie-based, unhashed passwords in JSON) for the exercise. For production, use secure sessions and hashed passwords.

Related: Issue #5 (Admin Mode)